### PR TITLE
List elems in paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,31 @@ Imagine a map (expressed in JSON format)
 }
 ```
 
+```
 1 = matryoshka.get("id").value(); 
 "Twenty-first James Bond movie" = matryoshka.get("desc").value();
 "Daniel" = matryoshka.get("starring").asList().get(0).get("name");
 "uk" = matryoshka.get("starring").asList().get(0).get("country/short");
+```
 
-or storing partial results to improve performance
+Or storing partial results to improve performance
 
+```
 Matryoshka danielCraig = matryoshka.get("starring").asList().get(0);
-"Daniel"= danielCraig.get("name")
-"uk"= danielCraig.get("country/short")
-"United Kingdom"= danielCraig.get("country/name")
+"Daniel" = danielCraig.get("name")
+"uk" = danielCraig.get("country/short")
+"United Kingdom" = danielCraig.get("country/name")
+```
 
+You can also use array indexes directly in paths
+
+```
+"Eva" = matryoshka.get("starring[1]/name")
+```
 
 ## API
 
-- get(String): To retrieve data from the map structure using map keys splitted with '/'. ex: get("/root/object/value") or get("root","object","value")
+- get(String): To retrieve data from the map structure using map keys splitted with `/`. You can also use `key[N]` to get the N element of an array in the key `key`. ex: `get("/root/object/value")` or `get("root/vegetables[0]/name")` or `get("root","object","value")`
 
 Once you are in a node you can retrieve data with:
 

--- a/src/test/java/cat/altimiras/matryoshka/MatryoshkaTest.java
+++ b/src/test/java/cat/altimiras/matryoshka/MatryoshkaTest.java
@@ -117,10 +117,39 @@ public class MatryoshkaTest {
 	}
 
 	@Test
+	public void listElemsInPath() throws Exception {
+
+		Map<String, Object> e1 = new HashMap<>(1);
+		e1.put("key", "111");
+		Map<String, Object> e2 = new HashMap<>(1);
+		e2.put("key", "222");
+
+		Map<String, Object> content = new HashMap<>();
+		content.put("list", Arrays.asList(e1, e2));
+		content.put("field1", "aaa");
+		content.put("field2", "bbb");
+
+		Map<String, Object> root = new HashMap<>();
+		root.put("root", content);
+		root.put("list", Arrays.asList(1, 2));
+
+		Matryoshka matryoshka = new Matryoshka(root);
+
+		assertEquals(2, matryoshka.get("root/list").asList().size());
+		assertEquals("111", matryoshka.get("root/list[0]/key").value());
+		assertEquals("222", matryoshka.get("root/list[1]/key").value());
+		assertTrue(matryoshka.get("root/list").value() instanceof List);
+
+		assertEquals(1, matryoshka.get("list[0]").value());
+		assertEquals(2, matryoshka.get("list[1]").value());
+	}
+
+	@Test
 	public void notExist() throws Exception {
 
 		Map<String, Object> content = new HashMap<>();
 		content.put("field1", "aaa");
+		content.put("list", Arrays.asList(1, 2));
 
 		Map<String, Object> root = new HashMap<>();
 		root.put("root", content);
@@ -131,8 +160,11 @@ public class MatryoshkaTest {
 		assertNull(matryoshka.get("anotherroot/otherfield").asMatryoshka());
 		assertNull(matryoshka.get("anotherroot").value());
 		assertNull(matryoshka.get("anotherroot/otherfield").value());
+		assertNull(matryoshka.get("anotherroot/otherfield[0]").value());
 		assertTrue(matryoshka.get("anotherroot").asList().isEmpty());
 		assertTrue(matryoshka.get("anotherroot/otherfield").asList().isEmpty());
+		assertNull(matryoshka.get("root/field1[0]").value());
+		assertNull(matryoshka.get("root/list[2]").value());
 	}
 
 	@Test(expected = Exception.class)


### PR DESCRIPTION
I've added support to define array elements directly in paths without use `asList` explicitly in the code.

ex:
`get("root/elements[3]/name")`